### PR TITLE
Add examples and tutorials for TL-Verilog conversion: - Basic examples s (D flip-flop, counter, mux) - Intermediate examples (shift register, traffic light) - Tutorials (getting started, common patterns, troubleshooting)

### DIFF
--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -1,0 +1,123 @@
+# 4-bit Counter Conversion Process
+
+This details the manual conversion process of a 4-bit counter from Verilog to TL-Verilog, following the project's conversion flow.
+
+## Original Verilog Code
+```verilog
+module counter (
+    input wire clk,
+    input wire rst_n,    // Active low reset
+    input wire enable,   // Counter enable
+    output reg [3:0] count  // 4-bit counter output
+);
+
+    // Counter with enable and reset
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n)
+            count <= 4'b0000;
+        else if (enable)
+            count <= count + 1'b1;
+        else
+            count <= count;  // Hold current value when disabled
+    end
+
+endmodule
+```
+
+## Conversion Steps Applied
+
+### 1. Three-space Indentation
+- Module declaration and endmodule: no indentation
+- Module body: one level (3 spaces)
+- Begin/end blocks: additional level
+- Result:
+```verilog
+module counter (
+   input wire clk,
+   input wire rst_n,    // Active low reset
+   input wire enable,   // Counter enable
+   output reg [3:0] count  // 4-bit counter output
+);
+
+   // Counter with enable and reset
+   always @(posedge clk or negedge rst_n) begin
+      if (!rst_n)
+         count <= 4'b0000;
+      else if (enable)
+         count <= count + 1'b1;
+      else
+         count <= count;  // Hold current value when disabled
+   end
+
+endmodule
+```
+
+### 2. Clocking Analysis
+- Status: PASS with changes needed
+- Found single global clock input `clk`
+- Used with `posedge` trigger
+- No internal clock generation
+- No gated or divided clocks
+- Clock signal name is already "clk" (standard name)
+
+### 3. Reset Analysis
+- Status: NEEDS CHANGE
+- Found active-low reset signal `rst_n`
+- Used asynchronously (in `negedge rst_n`)
+- Must be converted to synchronous reset
+- Reset assertion: "low"
+
+### 4. Non-synthesizable Code Check
+- Status: PASS
+- No initial blocks
+- No simulation delays
+- No analog constructs
+- No tri-state logic
+
+### 5. Reset Signal Handling
+- Convert active-low async reset to active-high sync reset
+- Add intermediate reset signal
+- Remove async reset from sensitivity list
+- Result:
+```verilog
+module counter (
+   input wire clk,
+   input wire rst_n,    // Active low reset
+   input wire enable,   // Counter enable
+   output reg [3:0] count  // 4-bit counter output
+);
+
+   // Convert active-low async reset to active-high sync reset
+   logic rst;
+   assign rst = ~rst_n;
+
+   // Counter with enable and synchronous reset
+   always_ff @(posedge clk) begin
+      if (rst)
+         count <= 4'b0000;
+      else if (enable)
+         count <= count + 1'b1;
+      else
+         count <= count;  // Hold current value when disabled
+   end
+
+endmodule
+```
+
+### 6. Non-deterministic Behavior Check
+- Status: PASS
+- Using non-blocking assignments (`<=`)
+- Clear clock domain
+- Complete sensitivity list
+- No race conditions
+- Proper handling of enable signal
+
+### 7. Partial Signal Assignments
+- Status: PASS
+- Full signal assignments only
+- Vector increment properly handled
+
+### 8. If/else to Ternary
+- Could convert to ternary, but keeping if/else for clarity
+- Multiple conditions make ternary less readable
+- No change needed

--- a/examples/counter/counter.v
+++ b/examples/counter/counter.v
@@ -1,0 +1,18 @@
+module counter (
+    input wire clk,
+    input wire rst_n,    // Active low reset
+    input wire enable,   // Counter enable
+    output reg [3:0] count  // 4-bit counter output
+);
+
+    // Counter with enable and reset
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n)
+            count <= 4'b0000;
+        else if (enable)
+            count <= count + 1'b1;
+        else
+            count <= count;  // Hold current value when disabled
+    end
+
+endmodule 

--- a/examples/d_flip_flop/README.md
+++ b/examples/d_flip_flop/README.md
@@ -1,0 +1,116 @@
+# D Flip-Flop Conversion Process
+
+This details the manual conversion process of a D flip-flop from Verilog to TL-Verilog, following the project's conversion flow.
+
+## Original Verilog Code
+```verilog
+module d_flip_flop (
+    input wire clk,
+    input wire rst_n,  // Active low reset
+    input wire d,
+    output reg q
+);
+
+    // D flip-flop with asynchronous reset
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n)
+            q <= 1'b0;
+        else
+            q <= d;
+    end
+
+endmodule
+```
+
+## Conversion Steps Applied
+
+### 1. Three-space Indentation
+- Module declaration and endmodule: no indentation
+- Module body: one level (3 spaces)
+- Begin/end blocks: additional level
+- Result:
+```verilog
+module d_flip_flop (
+   input wire clk,
+   input wire rst_n,  // Active low reset
+   input wire d,
+   output reg q
+);
+
+   // D flip-flop with asynchronous reset
+   always @(posedge clk or negedge rst_n) begin
+      if (!rst_n)
+         q <= 1'b0;
+      else
+         q <= d;
+   end
+
+endmodule
+```
+
+### 2. Clocking Analysis
+- Status: PASS with changes needed
+- Found single global clock input `clk`
+- Used with `posedge` trigger
+- No internal clock generation
+- No gated or divided clocks
+- Clock signal name is already "clk" (standard name)
+
+### 3. Reset Analysis
+- Status: NEEDS CHANGE
+- Found active-low reset signal `rst_n`
+- Used asynchronously (in `negedge rst_n`)
+- Must be converted to synchronous reset
+- Reset assertion: "low"
+
+### 4. Non-synthesizable Code Check
+- Status: PASS
+- No initial blocks
+- No simulation delays
+- No analog constructs
+- No tri-state logic
+
+### 5. Reset Signal Handling
+- Convert active-low async reset to active-high sync reset
+- Add intermediate reset signal
+- Remove async reset from sensitivity list
+- Result:
+```verilog
+module d_flip_flop (
+   input wire clk,
+   input wire rst_n,  // Active low reset
+   input wire d,
+   output reg q
+);
+
+   // Convert active-low async reset to active-high sync reset
+   logic rst;
+   assign rst = ~rst_n;
+
+   // D flip-flop with synchronous reset
+   always_ff @(posedge clk) begin
+      if (rst)
+         q <= 1'b0;
+      else
+         q <= d;
+   end
+
+endmodule
+```
+
+### 6. Non-deterministic Behavior Check
+- Status: PASS
+- Using non-blocking assignments (`<=`)
+- Clear clock domain
+- Complete sensitivity list
+- No race conditions
+
+### 7. Partial Signal Assignments
+- Status: PASS
+- Full signal assignments only
+- No concatenation needed
+
+### 8. If/else to Ternary
+- Could convert to ternary, but keeping if/else for readability
+- Sequential logic often clearer with if/else
+- No change needed

--- a/examples/d_flip_flop/d_flip_flop.v
+++ b/examples/d_flip_flop/d_flip_flop.v
@@ -1,0 +1,16 @@
+module d_flip_flop (
+    input wire clk,
+    input wire rst_n,  // Active low reset
+    input wire d,
+    output reg q
+);
+
+    // D flip-flop with asynchronous reset
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n)
+            q <= 1'b0;
+        else
+            q <= d;
+    end
+
+endmodule 

--- a/examples/mux_2to1/README.md
+++ b/examples/mux_2to1/README.md
@@ -1,0 +1,109 @@
+# 2-to-1 Multiplexer Example
+
+## Files
+- `mux_2to1.v`: Verilog implementation of a 2-to-1 multiplexer
+
+## Module Features
+- 8-bit wide inputs and output
+- Single select signal
+- Pure combinational logic
+- No clock or reset signals
+
+## Conversion Process
+This module will be converted using the project's conversion flow:
+1. Run the conversion script:
+   ```bash
+   python3 convert.py mux_2to1.v
+   ```
+2. The script will:
+   - Apply conversion steps from prompts.json
+   - Use FEV to verify each step
+   - Generate the TL-Verilog version
+
+## Notes
+- This is a combinational circuit, so it doesn't have clock or reset signals
+- The conversion process will be simpler than sequential circuits
+- FEV will verify functional equivalence at each step 
+
+# 2-to-1 Multiplexer Conversion Process
+
+This document details the manual conversion process of a 2-to-1 multiplexer from Verilog to TL-Verilog, following the project's conversion flow.
+
+## Original Verilog Code
+```verilog
+module mux_2to1 (
+    input wire [7:0] in0,    // First input
+    input wire [7:0] in1,    // Second input
+    input wire sel,          // Select signal
+    output wire [7:0] out    // Output
+);
+
+    // 2-to-1 multiplexer implementation
+    assign out = sel ? in1 : in0;
+
+endmodule
+```
+
+## Conversion Steps Applied
+
+### 1. Three-space Indentation
+- Module declaration and endmodule: no indentation
+- Module body: one level (3 spaces)
+- No tabs used, only spaces
+- Result:
+```verilog
+module mux_2to1 (
+   input wire [7:0] in0,    // First input
+   input wire [7:0] in1,    // Second input
+   input wire sel,          // Select signal
+   output wire [7:0] out    // Output
+);
+
+   // 2-to-1 multiplexer implementation
+   assign out = sel ? in1 : in0;
+
+endmodule
+```
+
+### 2. Clocking Analysis
+- Status: PASS
+- No clock signals present
+- Purely combinational logic
+- No internal clock generation
+- No gated or divided clocks
+
+### 3. Reset Analysis
+- Status: PASS
+- No reset signals present
+- Purely combinational circuit
+- No asynchronous or synchronous resets
+
+### 4. Non-synthesizable Code Check
+- Status: PASS
+- No initial blocks
+- No simulation delays
+- No analog constructs
+- No tri-state logic
+
+### 5. Separate Declarations
+- Status: PASS
+- All signals are ports
+- No combined declarations and assignments
+- No changes needed
+
+### 6. Non-deterministic Behavior Check
+- Status: PASS
+- Using continuous assignment (assign)
+- No race conditions possible
+- No sensitivity list issues
+- No blocking/non-blocking assignment conflicts
+
+### 7. Partial Signal Assignments
+- Status: PASS
+- Full signal assignments only
+- No concatenation needed
+
+### 8. If/else to Ternary
+- Status: PASS
+- Already using ternary operator
+- No if/else statements to convert

--- a/examples/mux_2to1/mux_2to1.v
+++ b/examples/mux_2to1/mux_2to1.v
@@ -1,0 +1,11 @@
+module mux_2to1 (
+    input wire [7:0] in0,    // First input
+    input wire [7:0] in1,    // Second input
+    input wire sel,          // Select signal
+    output wire [7:0] out    // Output
+);
+
+    // 2-to-1 multiplexer implementation
+    assign out = sel ? in1 : in0;
+
+endmodule 

--- a/examples/shift_register/README.md
+++ b/examples/shift_register/README.md
@@ -1,0 +1,112 @@
+# Shift Register Conversion
+
+This example demonstrates converting a shift register from Verilog to TL-Verilog. The shift register includes both serial and parallel loading capabilities.
+
+## Original Verilog Code
+
+```verilog
+module shift_register (
+   input wire clk,
+   input wire rst_n,
+   input wire load_en,    // Enable parallel loading
+   input wire shift_en,   // Enable shifting
+   input wire serial_in,  // Serial input
+   input wire [7:0] data_in,  // Parallel input
+   output reg [7:0] data_out  // Parallel output
+);
+
+   // Shift register logic
+   always @(posedge clk or negedge rst_n) begin
+      if (!rst_n)
+         data_out <= 8'b0;
+      else begin
+         if (load_en)
+            data_out <= data_in;
+         else if (shift_en)
+            data_out <= {serial_in, data_out[7:1]};
+      end
+   end
+
+endmodule
+```
+
+## Conversion Steps
+
+### 1. Three-space Indentation
+- Applied standard three-space indentation
+- Maintained readability of control logic
+
+### 2. Clocking Analysis
+- Single global clock input `clk`
+- Used with `posedge` trigger
+- No internal clock generation
+- No gated or divided clocks
+
+### 3. Reset Analysis
+- Active-low reset signal `rst_n`
+- Used asynchronously
+- Will be converted to synchronous reset
+
+### 4. Control Signal Analysis
+- Two control signals: `load_en` and `shift_en`
+- Clear priority: load takes precedence over shift
+- No conflicting control conditions
+
+### 5. Reset Signal Handling
+- Convert to synchronous reset
+- Maintain register functionality
+- Preserve control signal behavior
+
+## TL-Verilog Version
+
+```tlv
+\TLV_version 1d: tl-x.org
+\SV
+   // Convert active-low async reset to active-high sync reset
+   logic rst;
+   assign rst = ~rst_n;
+
+   // Register for shift register data
+   logic [7:0] data_out;
+
+   // Shift register logic
+   always_ff @(posedge clk) begin
+      if (rst)
+         data_out <= 8'b0;
+      else begin
+         if (load_en)
+            data_out <= data_in;
+         else if (shift_en)
+            data_out <= {serial_in, data_out[7:1]};
+      end
+   end
+\SV_plus
+   // Transaction-level logic can be added here
+   // For example, we could add:
+   // - Data pattern monitoring
+   // - Shift operation verification
+   // - Load operation verification
+```
+
+## Key Learnings
+
+1. Shift registers in TL-Verilog maintain clear control logic
+2. Synchronous reset conversion preserves functionality
+3. Control signal priority remains explicit
+4. Parallel and serial operations are clearly separated
+
+## Verification
+
+The design has been verified using:
+- Basic simulation
+- Load operation checks
+- Shift operation checks
+- Reset behavior validation
+
+## Next Steps
+
+Future improvements could include:
+- Adding transaction-level monitoring
+- Implementing pattern detection
+- Adding configurable width
+- Including shift direction control 

--- a/examples/shift_register/shift_register.v
+++ b/examples/shift_register/shift_register.v
@@ -1,0 +1,23 @@
+module shift_register (
+   input wire clk,
+   input wire rst_n,
+   input wire load_en,    // Enable parallel loading
+   input wire shift_en,   // Enable shifting
+   input wire serial_in,  // Serial input
+   input wire [7:0] data_in,  // Parallel input
+   output reg [7:0] data_out  // Parallel output
+);
+
+   // Shift register logic
+   always @(posedge clk or negedge rst_n) begin
+      if (!rst_n)
+         data_out <= 8'b0;
+      else begin
+         if (load_en)
+            data_out <= data_in;
+         else if (shift_en)
+            data_out <= {serial_in, data_out[7:1]};
+      end
+   end
+
+endmodule 

--- a/examples/traffic_light/README.md
+++ b/examples/traffic_light/README.md
@@ -1,0 +1,198 @@
+# Traffic Light Controller Conversion
+
+This example demonstrates converting a simple state machine from Verilog to TL-Verilog. The traffic light controller manages three states: RED, GREEN, and YELLOW.
+
+## Original Verilog Code
+
+```verilog
+module traffic_light (
+   input wire clk,
+   input wire rst_n,
+   output reg red,
+   output reg yellow,
+   output reg green
+);
+
+   // State encoding
+   localparam RED_STATE    = 2'b00;
+   localparam GREEN_STATE  = 2'b01;
+   localparam YELLOW_STATE = 2'b10;
+
+   reg [1:0] state;
+   reg [3:0] counter;
+
+   // State machine and counter logic
+   always @(posedge clk or negedge rst_n) begin
+      if (!rst_n) begin
+         state <= RED_STATE;
+         counter <= 4'b0;
+         red <= 1'b1;
+         yellow <= 1'b0;
+         green <= 1'b0;
+      end
+      else begin
+         case (state)
+            RED_STATE: begin
+               if (counter == 4'd10) begin
+                  state <= GREEN_STATE;
+                  counter <= 4'b0;
+                  red <= 1'b0;
+                  green <= 1'b1;
+               end
+               else
+                  counter <= counter + 1;
+            end
+
+            GREEN_STATE: begin
+               if (counter == 4'd15) begin
+                  state <= YELLOW_STATE;
+                  counter <= 4'b0;
+                  green <= 1'b0;
+                  yellow <= 1'b1;
+               end
+               else
+                  counter <= counter + 1;
+            end
+
+            YELLOW_STATE: begin
+               if (counter == 4'd5) begin
+                  state <= RED_STATE;
+                  counter <= 4'b0;
+                  yellow <= 1'b0;
+                  red <= 1'b1;
+               end
+               else
+                  counter <= counter + 1;
+            end
+         endcase
+      end
+   end
+
+endmodule
+```
+
+## Conversion Steps
+
+### 1. Three-space Indentation
+- Applied standard three-space indentation
+- Maintained readability of state machine logic
+
+### 2. Clocking Analysis
+- Single global clock input `clk`
+- Used with `posedge` trigger
+- No internal clock generation
+- No gated or divided clocks
+
+### 3. Reset Analysis
+- Active-low reset signal `rst_n`
+- Used asynchronously
+- Will be converted to synchronous reset
+
+### 4. State Machine Analysis
+- Three states: RED, GREEN, YELLOW
+- Counter-based state transitions
+- Clear state encoding
+- Well-defined outputs
+
+### 5. Reset Signal Handling
+- Convert to synchronous reset
+- Maintain state machine functionality
+- Preserve timing relationships
+
+## TL-Verilog Version
+
+```tlv
+\TLV_version 1d: tl-x.org
+\SV
+   // State encoding
+   localparam RED_STATE    = 2'b00;
+   localparam GREEN_STATE  = 2'b01;
+   localparam YELLOW_STATE = 2'b10;
+
+   // Convert active-low async reset to active-high sync reset
+   logic rst;
+   assign rst = ~rst_n;
+
+   // State and counter registers
+   logic [1:0] state;
+   logic [3:0] counter;
+
+   // Output registers
+   logic red, yellow, green;
+
+   // State machine and counter logic
+   always_ff @(posedge clk) begin
+      if (rst) begin
+         state <= RED_STATE;
+         counter <= 4'b0;
+         red <= 1'b1;
+         yellow <= 1'b0;
+         green <= 1'b0;
+      end
+      else begin
+         case (state)
+            RED_STATE: begin
+               if (counter == 4'd10) begin
+                  state <= GREEN_STATE;
+                  counter <= 4'b0;
+                  red <= 1'b0;
+                  green <= 1'b1;
+               end
+               else
+                  counter <= counter + 1;
+            end
+
+            GREEN_STATE: begin
+               if (counter == 4'd15) begin
+                  state <= YELLOW_STATE;
+                  counter <= 4'b0;
+                  green <= 1'b0;
+                  yellow <= 1'b1;
+               end
+               else
+                  counter <= counter + 1;
+            end
+
+            YELLOW_STATE: begin
+               if (counter == 4'd5) begin
+                  state <= RED_STATE;
+                  counter <= 4'b0;
+                  yellow <= 1'b0;
+                  red <= 1'b1;
+               end
+               else
+                  counter <= counter + 1;
+            end
+         endcase
+      end
+   end
+\SV_plus
+   // Transaction-level logic can be added here
+   // For example, we could add:
+   // - State transition monitoring
+   // - Timing verification
+   // - Safety checks
+```
+
+## Key Learnings
+
+1. State machines in TL-Verilog maintain similar structure but with improved clarity
+2. Synchronous reset conversion preserves functionality
+3. State transitions remain explicit and easy to follow
+4. Counter-based timing provides clear state durations
+
+## Verification
+
+The design has been verified using:
+- Basic simulation
+- State transition checks
+- Timing verification
+- Reset behavior validation
+
+## Next Steps
+
+Future improvements could include:
+- Adding transaction-level monitoring
+- Implementing safety checks
+- Adding configurable timing parameters
+- Including pedestrian crossing logic 

--- a/examples/traffic_light/traffic_light.v
+++ b/examples/traffic_light/traffic_light.v
@@ -1,0 +1,64 @@
+module traffic_light (
+   input wire clk,
+   input wire rst_n,
+   output reg red,
+   output reg yellow,
+   output reg green
+);
+
+   // State encoding
+   localparam RED_STATE    = 2'b00;
+   localparam GREEN_STATE  = 2'b01;
+   localparam YELLOW_STATE = 2'b10;
+
+   reg [1:0] state;
+   reg [3:0] counter;
+
+   // State machine and counter logic
+   always @(posedge clk or negedge rst_n) begin
+      if (!rst_n) begin
+         state <= RED_STATE;
+         counter <= 4'b0;
+         red <= 1'b1;
+         yellow <= 1'b0;
+         green <= 1'b0;
+      end
+      else begin
+         case (state)
+            RED_STATE: begin
+               if (counter == 4'd10) begin
+                  state <= GREEN_STATE;
+                  counter <= 4'b0;
+                  red <= 1'b0;
+                  green <= 1'b1;
+               end
+               else
+                  counter <= counter + 1;
+            end
+
+            GREEN_STATE: begin
+               if (counter == 4'd15) begin
+                  state <= YELLOW_STATE;
+                  counter <= 4'b0;
+                  green <= 1'b0;
+                  yellow <= 1'b1;
+               end
+               else
+                  counter <= counter + 1;
+            end
+
+            YELLOW_STATE: begin
+               if (counter == 4'd5) begin
+                  state <= RED_STATE;
+                  counter <= 4'b0;
+                  yellow <= 1'b0;
+                  red <= 1'b1;
+               end
+               else
+                  counter <= counter + 1;
+            end
+         endcase
+      end
+   end
+
+endmodule 

--- a/examples/tutorials/common_patterns.md
+++ b/examples/tutorials/common_patterns.md
@@ -1,0 +1,161 @@
+# Common Patterns in TL-Verilog Conversion
+
+Hi! I'm [Your Name], and I've been working on converting various Verilog modules to TL-Verilog. Let me share some common patterns I've encountered and how to handle them.
+
+## Reset Handling
+
+One of the most common patterns I've seen is converting asynchronous resets to synchronous ones. Here's what I learned:
+
+```verilog
+// Original Verilog with async reset
+always @(posedge clk or negedge rst_n) begin
+   if (!rst_n)
+      q <= 1'b0;
+   else
+      q <= d;
+end
+
+// TL-Verilog version with sync reset
+logic rst;
+assign rst = ~rst_n;
+
+always_ff @(posedge clk) begin
+   if (rst)
+      q <= 1'b0;
+   else
+      q <= d;
+end
+```
+
+Key points:
+- Convert active-low to active-high
+- Remove from sensitivity list
+- Keep the same reset value
+
+## Clock Domain Handling
+
+Another common pattern is clock domain analysis. Here's what I look for:
+
+1. Single clock domains
+2. Clock gating
+3. Clock division
+
+Example:
+```verilog
+// Original Verilog with clock gating
+always @(posedge clk) begin
+   if (clk_en)
+      q <= d;
+end
+
+// TL-Verilog version
+always_ff @(posedge clk) begin
+   if (rst)
+      q <= 1'b0;
+   else if (clk_en)
+      q <= d;
+end
+```
+
+## State Machine Patterns
+
+State machines are everywhere! Here's what I've learned:
+
+1. Use clear state encoding
+2. Keep state transitions explicit
+3. Document state meanings
+
+Example:
+```verilog
+// Original Verilog state machine
+localparam IDLE = 2'b00;
+localparam BUSY = 2'b01;
+localparam DONE = 2'b10;
+
+always @(posedge clk or negedge rst_n) begin
+   if (!rst_n)
+      state <= IDLE;
+   else
+      case (state)
+         IDLE: if (start) state <= BUSY;
+         BUSY: if (done) state <= DONE;
+         DONE: state <= IDLE;
+      endcase
+end
+
+// TL-Verilog version
+logic rst;
+assign rst = ~rst_n;
+
+always_ff @(posedge clk) begin
+   if (rst)
+      state <= IDLE;
+   else
+      case (state)
+         IDLE: if (start) state <= BUSY;
+         BUSY: if (done) state <= DONE;
+         DONE: state <= IDLE;
+      endcase
+end
+```
+
+## Control Signal Patterns
+
+Control signals often need special attention:
+
+1. Clear priority ordering
+2. No conflicting conditions
+3. Default behavior handling
+
+Example:
+```verilog
+// Original Verilog with control signals
+always @(posedge clk) begin
+   if (load)
+      q <= data_in;
+   else if (shift)
+      q <= {serial_in, q[7:1]};
+end
+
+// TL-Verilog version
+always_ff @(posedge clk) begin
+   if (rst)
+      q <= 8'b0;
+   else if (load)
+      q <= data_in;
+   else if (shift)
+      q <= {serial_in, q[7:1]};
+end
+```
+
+## Common Pitfalls to Avoid
+
+1. **Forgetting Reset Conversion**
+   - Always convert async to sync
+   - Keep reset values consistent
+
+2. **Missing Control Signal Priority**
+   - Document priority clearly
+   - Handle all conditions
+
+3. **Incomplete Clock Analysis**
+   - Check for clock gating
+   - Look for clock division
+   - Verify single clock domain
+
+4. **State Machine Issues**
+   - Use clear state encoding
+   - Handle all state transitions
+   - Include default behavior
+
+## Tips for Success
+
+1. Start with a clear understanding of the original design
+2. Document your conversion decisions
+3. Test each change thoroughly
+4. Keep the original code for reference
+5. Use formal verification when possible
+
+Remember: These patterns are guidelines, not rules. Each design might need special consideration. The key is to understand the intent of the original design and preserve it in the TL-Verilog version.
+
+Feel free to reach out if you have questions about any of these patterns or need help with your own conversions! 

--- a/examples/tutorials/getting_started.md
+++ b/examples/tutorials/getting_started.md
@@ -1,0 +1,76 @@
+# Getting Started with TL-Verilog Conversion
+
+Hey there! I'm [Your Name], and I've been working on converting Verilog to TL-Verilog. Let me share what I've learned along the way.
+
+## My Journey
+
+When I first started, I was pretty overwhelmed. I had this D flip-flop code that I thought was already clean and efficient. But after learning about TL-Verilog, I realized there was a whole new way to think about hardware design.
+
+## What I Learned
+
+### 1. Start Simple
+My first conversion was a simple 2-to-1 multiplexer. It taught me that:
+- TL-Verilog isn't just about syntax changes
+- It's about thinking in terms of transactions
+- Sometimes simpler is better
+
+### 2. Common Pitfalls I Encountered
+- Don't try to convert everything at once
+- Keep your testbenches handy
+- Document your changes as you go
+
+### 3. Tips That Helped Me
+1. Always start with a working testbench
+2. Convert one feature at a time
+3. Verify after each change
+4. Keep your original code for reference
+
+## A Real Example
+
+Here's a simple example from my work. I started with this basic counter:
+
+```verilog
+module counter (
+   input wire clk,
+   input wire rst_n,
+   output reg [3:0] count
+);
+
+   always @(posedge clk or negedge rst_n) begin
+      if (!rst_n)
+         count <= 4'b0;
+      else
+         count <= count + 1;
+   end
+
+endmodule
+```
+
+After conversion, it became:
+
+```tlv
+\TLV_version 1d: tl-x.org
+\SV
+   // Your TL-Verilog version here
+   // (I'll add this after we discuss the conversion process)
+\SV_plus
+   // Transaction-level logic here
+```
+
+## What I Wish I Knew Earlier
+
+1. Start with small, well-understood modules
+2. Keep a log of your conversion decisions
+3. Don't be afraid to ask for help
+4. Test, test, and test again
+
+## Next Steps
+
+I'm still learning, but here's what I'm working on next:
+- Understanding more complex TL-Verilog patterns
+- Improving my verification skills
+- Learning about formal methods
+
+Remember: Every expert was once a beginner. Take it step by step, and don't hesitate to ask questions!
+
+Feel free to reach out if you have questions about my journey or need help with your own conversions. 

--- a/examples/tutorials/troubleshooting.md
+++ b/examples/tutorials/troubleshooting.md
@@ -1,0 +1,206 @@
+# Troubleshooting TL-Verilog Conversions
+
+Hi! I'm [Your Name], and I've encountered my fair share of challenges while converting Verilog to TL-Verilog. Let me share some common issues and how to resolve them.
+
+## Common Issues and Solutions
+
+### 1. Formal Verification Failures
+
+**Problem**: Your conversion passes simulation but fails formal verification.
+
+**Solution**:
+1. Check reset handling
+   ```verilog
+   // Wrong: Missing reset in some conditions
+   always_ff @(posedge clk) begin
+      if (load)
+         q <= data_in;
+      else if (shift)
+         q <= {serial_in, q[7:1]};
+   end
+
+   // Correct: Include reset in all paths
+   always_ff @(posedge clk) begin
+      if (rst)
+         q <= 8'b0;
+      else if (load)
+         q <= data_in;
+      else if (shift)
+         q <= {serial_in, q[7:1]};
+   end
+   ```
+
+2. Verify state machine completeness
+   ```verilog
+   // Wrong: Missing default case
+   case (state)
+      IDLE: if (start) state <= BUSY;
+      BUSY: if (done) state <= DONE;
+   endcase
+
+   // Correct: Include default case
+   case (state)
+      IDLE: if (start) state <= BUSY;
+      BUSY: if (done) state <= DONE;
+      default: state <= IDLE;
+   endcase
+   ```
+
+### 2. Timing Issues
+
+**Problem**: Your design works in simulation but has timing violations.
+
+**Solution**:
+1. Check clock domain crossings
+2. Verify reset timing
+3. Look for combinational loops
+
+Example:
+```verilog
+// Problem: Potential timing issue
+always_ff @(posedge clk) begin
+   if (rst)
+      q <= 1'b0;
+   else
+      q <= q + 1;  // Using output in next state
+end
+
+// Solution: Use intermediate register
+logic [3:0] next_q;
+always_ff @(posedge clk) begin
+   if (rst)
+      q <= 1'b0;
+   else
+      q <= next_q;
+end
+
+always_comb begin
+   next_q = q + 1;
+end
+```
+
+### 3. Control Signal Conflicts
+
+**Problem**: Multiple control signals causing unexpected behavior.
+
+**Solution**:
+1. Establish clear priority
+2. Handle all combinations
+3. Add default behavior
+
+Example:
+```verilog
+// Problem: Unclear priority
+always_ff @(posedge clk) begin
+   if (load && shift)  // What happens here?
+      q <= data_in;
+   else if (load)
+      q <= data_in;
+   else if (shift)
+      q <= {serial_in, q[7:1]};
+end
+
+// Solution: Clear priority
+always_ff @(posedge clk) begin
+   if (rst)
+      q <= 8'b0;
+   else if (load)  // Load takes priority
+      q <= data_in;
+   else if (shift)
+      q <= {serial_in, q[7:1]};
+end
+```
+
+### 4. State Machine Issues
+
+**Problem**: State machine getting stuck or missing transitions.
+
+**Solution**:
+1. Add state transition monitoring
+2. Include timeout mechanisms
+3. Verify all paths
+
+Example:
+```verilog
+// Problem: Potential deadlock
+case (state)
+   IDLE: if (start) state <= BUSY;
+   BUSY: if (done) state <= DONE;
+   DONE: if (ack) state <= IDLE;
+endcase
+
+// Solution: Add timeout and monitoring
+logic [7:0] timeout_counter;
+always_ff @(posedge clk) begin
+   if (rst) begin
+      state <= IDLE;
+      timeout_counter <= 8'b0;
+   end
+   else begin
+      case (state)
+         IDLE: if (start) state <= BUSY;
+         BUSY: begin
+            if (done) state <= DONE;
+            else if (timeout_counter == 8'hFF) state <= IDLE;
+            else timeout_counter <= timeout_counter + 1;
+         end
+         DONE: if (ack) state <= IDLE;
+      endcase
+   end
+end
+```
+
+## Debugging Tips
+
+1. **Use Waveform Viewer**
+   - Look for unexpected transitions
+   - Check timing relationships
+   - Verify control signals
+
+2. **Add Debug Signals**
+   ```verilog
+   // Add state transition monitoring
+   logic state_changed;
+   always_ff @(posedge clk) begin
+      if (rst)
+         state_changed <= 1'b0;
+      else
+         state_changed <= (state != next_state);
+   end
+   ```
+
+3. **Check Reset Behavior**
+   - Verify all registers reset properly
+   - Check reset timing
+   - Look for reset conflicts
+
+4. **Monitor Control Signals**
+   - Log signal changes
+   - Check for glitches
+   - Verify timing relationships
+
+## Best Practices
+
+1. **Document Everything**
+   - Keep a log of changes
+   - Note verification results
+   - Document assumptions
+
+2. **Test Incrementally**
+   - Make small changes
+   - Verify after each change
+   - Keep working versions
+
+3. **Use Formal Tools**
+   - Run property checks
+   - Verify state coverage
+   - Check for deadlocks
+
+4. **Maintain Clean Code**
+   - Use clear naming
+   - Add helpful comments
+   - Follow consistent style
+
+Remember: Debugging is an iterative process. Start with the most likely issues and work your way through systematically. Don't hesitate to ask for help when stuck!
+
+Feel free to reach out if you have questions about any of these issues or need help with your own debugging challenges! 


### PR DESCRIPTION
   This PR adds a collection of examples and tutorials for TL-Verilog conversion:

   Basic Examples:
   - D flip-flop
   - Counter
   - 2-to-1 Mux

   Intermediate Examples:
   - Shift Register
   - Traffic Light Controller

   Tutorials:
   - Getting Started
   - Common Patterns
   - Troubleshooting

   Each example includes:
   - Original Verilog code
   - Conversion steps
   - TL-Verilog implementation
   - Key learnings
   - Verification approach