### PR TITLE
Add reference to  conversion examples repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ Here are a few ideas to prepare for contributing:
 
 The intent is improve LLMs' ability to convert Verilog to TL-Verilog. We teach it through prompts. We convert. The conversion process captures what we've done. LLMs can train on this to become more savvy. Initially, there will be a lot of human guidance. Over time the LLMs become more capable.
 
+## Conversion Examples
+
+### By sharma-sugurthi
+Repository: [TL-Verilog Conversion Examples](https://github.com/sharma-sugurthi/conversion-to-TLV)
+- Basic circuits (D flip-flop, counter, 2-to-1 mux)
+- Intermediate designs (shift register, traffic light controller)
+- Sequence detector with state machine
+- Detailed conversion steps and tutorials
+
 So, where do we keep all this training data. Here are the current thoughts:
   - Fork this repo.
   - Do some conversions.


### PR DESCRIPTION
This PR adds a reference to my repository containing Verilog to TL-Verilog conversion examples in `Conversions.md`.

My repository (https://github.com/sharma-sugurthi/conversion-to-TLV) contains:

1. Basic Circuit Conversions:
   - D flip-flop with synchronous reset
   - 4-bit counter with enable functionality
   - 2-to-1 multiplexer (8-bit)

2. Intermediate Design Conversions:
   - 8-bit shift register with parallel load
   - Traffic light controller state machine
   - Sequence detector (pattern "101")

3. Tutorials:
   - Detailed step-by-step conversion process
   - Common conversion patterns and best practices
   - Troubleshooting guidelines