### PR TITLE
Automation: recover from FEV failures by reverting and retrying with feedback

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -1884,6 +1884,26 @@ def run_fev(orig_file_name, working_verilog_file_name, use_eqy = True):
   # TODO: If failed, bundle failure info for LLM, and call LLM (with approval).
   return proc.returncode == 0
 
+def recover_from_fev_failure():
+  """Revert the working code to the most recently FEVed version and mark the step
+  incomplete with feedback. Without this, automation dead-loops: the step reads as
+  "LLM already completed" so the LLM is never re-run, but the saved code can never
+  pass FEV (e.g. a renamed module port)."""
+  try:
+    good = most_recently_feved_verilog_file()
+    os.system("cp " + good + " " + working_verilog_file_name)
+    status = readStatus()
+    status["incomplete"] = True
+    status["plan"] = ("A previous attempt at this step FAILED formal equivalence verification, "
+                      "and the code has been reverted to the last verified version. Retry with "
+                      "smaller, safer changes. Do NOT rename module ports or change the module "
+                      "interface, and do NOT change functional behavior.")
+    writeStatus(status)
+    print("  Reverted to last FEVed code; step marked incomplete for retry with feedback.")
+  except Exception as e:
+    print(f"  Warning: FEV-failure recovery failed: {e}")
+
+
 def run_fev_automated():
   """Run FEV in automated mode, return True if successful"""
   global automation_errors
@@ -1894,6 +1914,7 @@ def run_fev_automated():
     
     if not success:
       automation_errors.append("FEV failed - code changes may have introduced errors")
+      recover_from_fev_failure()
       return False
         
     print("  FEV passed successfully")


### PR DESCRIPTION
When a step's saved code fails FEV, automation dead-loops: the step reads as "LLM already completed" so the LLM is never re-run, but the saved code can never pass FEV. A typical case is a model renaming an output port.

This adds recover_from_fev_failure(): on FEV failure, revert the working code to the most recently FEVed version, mark the step incomplete, and record the failure reason in the status "plan" field, which already flows into the next LLM request. The model then retries from the last verified state knowing why the previous attempt failed. This is the counterexample-feedback pattern from the SpecLoop paper we discussed, applied to this flow.

Measured effect on the counter comparison: gpt-4o and claude-haiku-4-5 had both introduced real FEV failures (an extra register delaying the output by one cycle, and a dropped declaration truncating a signal to 1 bit). Without this change both were stuck permanently; with it both recovered and completed the full recipe. Gemini still failed (it kept renaming a port even with feedback), so this does not mask real capability limits, it just stops the flow from dying on recoverable ones.