### PR TITLE
Support OpenAI-compatible endpoints without /models, refresh model names

### DIFF
--- a/config/models.json
+++ b/config/models.json
@@ -1,125 +1,345 @@
 {
     "models": {
-        "gpt-3.5-turbo": {"api": "gpt3"},
-        "gpt-3.5-turbo-16k": {"api": "gpt3"},
-        "gpt-3.5-turbo-1106": {"api": "gpt3"},
-        "gpt-3.5-turbo-0125": {"api": "gpt3"},
-        "gpt-3.5-turbo-instruct": {"api": "gpt3"},
-        "gpt-3.5-turbo-instruct-0914": {"api": "gpt3"},
-        "gpt-4": {"api": "gpt4"},
-        "gpt-4-0613": {"api": "gpt4"},
-        "gpt-4-1106-preview": {"api": "gpt4"},
-        "gpt-4-0125-preview": {"api": "gpt4"},
-        "gpt-4-turbo": {"api": "gpt4"},
-        "gpt-4-turbo-preview": {"api": "gpt4"},
-        "gpt-4-turbo-2024-04-09": {"api": "gpt4"},
-        "gpt-5": { "api": "gpt5" },
-        "gpt-5-mini": { "api": "gpt5-mini" },
-        "gpt-5-nano": { "api": "gpt5-nano" },
-        "gpt-5-chat-latest": { "api": "gpt5-chat-latest" },
-        "gpt-4o": {"api": "o"},
-        "gpt-4o-2024-05-13": {"api": "o"},
-        "gpt-4o-2024-08-06": {"api": "o"},
-        "gpt-4o-2024-11-20": {"api": "o"},
-        "gpt-4o-realtime-preview": {"api": "o"},
-        "gpt-4o-realtime-preview-2025-06-03": {"api": "o"},
-        "gpt-4o-realtime-preview-2024-10-01": {"api": "o"},
-        "gpt-4o-realtime-preview-2024-12-17": {"api": "o"},
-        "gpt-4o-search-preview": {"api": "o"},
-        "gpt-4o-search-preview-2025-03-11": {"api": "o"},
-        "gpt-4o-audio-preview": {"api": "o"},
-        "gpt-4o-audio-preview-2025-06-03": {"api": "o"},
-        "gpt-4o-audio-preview-2024-10-01": {"api": "o"},
-        "gpt-4o-audio-preview-2024-12-17": {"api": "o"},
-        "gpt-4o-transcribe": {"api": "o"},
-        "gpt-4o-mini-transcribe": {"api": "o"},
-        "gpt-4o-mini-search-preview": {"api": "o"},
-        "gpt-4o-mini-search-preview-2025-03-11": {"api": "o"},
-        "gpt-4o-mini-realtime-preview": {"api": "o"},
-        "gpt-4o-mini-realtime-preview-2024-12-17": {"api": "o"},
-        "gpt-4o-mini-audio-preview": {"api": "o"},
-        "gpt-4o-mini-audio-preview-2024-12-17": {"api": "o"},
-        "gpt-4o-mini": {"api": "o"},
-        "gpt-4o-mini-2024-07-18": {"api": "o"},
-        "chatgpt-4o-latest": {"api": "o"},
-        "gpt-4o-2024-06-26": {"api": "o"}, 
-        "gpt-4o-mini-tts": {"api": "o"},
-        "o1": {"api": "o"},
-        "o1-2024-12-17": {"api": "o"},
-        "o1-pro": {"api": "o"},
-        "o1-pro-2025-03-19": {"api": "o"},
-        "o3-mini": {"api": "o"},
-        "o3-mini-2025-01-31": {"api": "o"},
-        "o4-mini": {"api": "o-simple"},
-        "o4-mini-2025-04-16": {"api": "o-simple"},
-        "o4-mini-deep-research": {"api": "o-simple"},
-        "o4-mini-deep-research-2025-06-26": {"api": "o-simple"},
-        "o1-mini": {"api": "o-simple"},
-        "o1-mini-2024-09-12": {"api": "o-simple"},
-        "codex-mini-latest": {"api": "o-simple"},
-        "gemini-1.5-pro": {"api": "gemini"},
-        "gemini-1.5-pro-002": {"api": "gemini"},
-        "gemini-1.5-pro-latest": {"api": "gemini"},
-        "gemini-2.5-pro": {"api": "gemini"},
-        "gemini-2.5-pro-preview-03-25": {"api": "gemini"},
-        "gemini-2.5-pro-preview-05-06": {"api": "gemini"},
-        "gemini-2.5-pro-preview-06-05": {"api": "gemini"},
-        "gemini-2.5-pro-preview-tts": {"api": "gemini"},
-        "gemini-2.0-pro-exp": {"api": "gemini"},
-        "gemini-2.0-pro-exp-02-05": {"api": "gemini"},
-        "gemini-exp-1206": {"api": "gemini"},
-        "gemini-2.0-flash-thinking-exp": {"api": "gemini"},
-        "gemini-2.0-flash-thinking-exp-01-21": {"api": "gemini"},
-        "gemini-2.0-flash-thinking-exp-1219": {"api": "gemini"},
-        "gemini-1.5-flash": {"api": "gemini-flash"},
-        "gemini-1.5-flash-002": {"api": "gemini-flash"},
-        "gemini-1.5-flash-latest": {"api": "gemini-flash"},
-        "gemini-1.5-flash-8b": {"api": "gemini-flash"},
-        "gemini-1.5-flash-8b-001": {"api": "gemini-flash"},
-        "gemini-1.5-flash-8b-latest": {"api": "gemini-flash"},
-        "gemini-2.5-flash": {"api": "gemini-flash"},
-        "gemini-2.5-flash-preview-05-20": {"api": "gemini-flash"},
-        "gemini-2.5-flash-lite": {"api": "gemini-flash"},
-        "gemini-2.5-flash-lite-preview-06-17": {"api": "gemini-flash"},
-        "gemini-2.0-flash": {"api": "gemini-flash"},
-        "gemini-2.0-flash-exp": {"api": "gemini-flash"},
-        "gemini-2.0-flash-001": {"api": "gemini-flash"},
-        "gemini-2.0-flash-lite": {"api": "gemini-flash"},
-        "gemini-2.0-flash-lite-001": {"api": "gemini-flash"},
-        "gemini-2.0-flash-lite-preview": {"api": "gemini-flash"},
-        "gemini-2.0-flash-lite-preview-02-05": {"api": "gemini-flash"},
-        "gemini-2.5-flash-preview-native-audio-dialog": {"api": "gemini-flash"},
-        "gemini-2.5-flash-exp-native-audio-thinking-dialog": {"api": "gemini-flash"},
-        "gemini-2.0-flash-live-001": {"api": "gemini-flash"},
-        "gemini-live-2.5-flash-preview": {"api": "gemini-flash"},
-        "gemini-2.5-flash-live-preview": {"api": "gemini-flash"},
-        "gemini-2.5-flash-preview-tts": {"api": "gemini-flash"},
-        "learnlm-2.0-flash-experimental": {"api": "gemini-flash"},
-        "claude-opus-4-20250514": { "api": "claude" },
-        "claude-sonnet-4-20250514": { "api": "claude" },
-        "claude-3-7-sonnet-20250219": { "api": "claude" },
-        "claude-3-5-sonnet-20241022": { "api": "claude" },
-        "claude-3-5-haiku-20241022": { "api": "claude" },
-        "claude-3-5-sonnet-20240620": { "api": "claude" },
-        "claude-3-haiku-20240307": { "api": "claude" }
+        "gpt-3.5-turbo": {
+            "api": "gpt3"
+        },
+        "gpt-3.5-turbo-16k": {
+            "api": "gpt3"
+        },
+        "gpt-3.5-turbo-1106": {
+            "api": "gpt3"
+        },
+        "gpt-3.5-turbo-0125": {
+            "api": "gpt3"
+        },
+        "gpt-3.5-turbo-instruct": {
+            "api": "gpt3"
+        },
+        "gpt-3.5-turbo-instruct-0914": {
+            "api": "gpt3"
+        },
+        "gpt-4": {
+            "api": "gpt4"
+        },
+        "gpt-4-0613": {
+            "api": "gpt4"
+        },
+        "gpt-4-1106-preview": {
+            "api": "gpt4"
+        },
+        "gpt-4-0125-preview": {
+            "api": "gpt4"
+        },
+        "gpt-4-turbo": {
+            "api": "gpt4"
+        },
+        "gpt-4-turbo-preview": {
+            "api": "gpt4"
+        },
+        "gpt-4-turbo-2024-04-09": {
+            "api": "gpt4"
+        },
+        "gpt-5": {
+            "api": "gpt5"
+        },
+        "gpt-5-mini": {
+            "api": "gpt5-mini"
+        },
+        "gpt-5-nano": {
+            "api": "gpt5-nano"
+        },
+        "gpt-5-chat-latest": {
+            "api": "gpt5-chat-latest"
+        },
+        "gpt-4o": {
+            "api": "o"
+        },
+        "gpt-4o-2024-05-13": {
+            "api": "o"
+        },
+        "gpt-4o-2024-08-06": {
+            "api": "o"
+        },
+        "gpt-4o-2024-11-20": {
+            "api": "o"
+        },
+        "gpt-4o-realtime-preview": {
+            "api": "o"
+        },
+        "gpt-4o-realtime-preview-2025-06-03": {
+            "api": "o"
+        },
+        "gpt-4o-realtime-preview-2024-10-01": {
+            "api": "o"
+        },
+        "gpt-4o-realtime-preview-2024-12-17": {
+            "api": "o"
+        },
+        "gpt-4o-search-preview": {
+            "api": "o"
+        },
+        "gpt-4o-search-preview-2025-03-11": {
+            "api": "o"
+        },
+        "gpt-4o-audio-preview": {
+            "api": "o"
+        },
+        "gpt-4o-audio-preview-2025-06-03": {
+            "api": "o"
+        },
+        "gpt-4o-audio-preview-2024-10-01": {
+            "api": "o"
+        },
+        "gpt-4o-audio-preview-2024-12-17": {
+            "api": "o"
+        },
+        "gpt-4o-transcribe": {
+            "api": "o"
+        },
+        "gpt-4o-mini-transcribe": {
+            "api": "o"
+        },
+        "gpt-4o-mini-search-preview": {
+            "api": "o"
+        },
+        "gpt-4o-mini-search-preview-2025-03-11": {
+            "api": "o"
+        },
+        "gpt-4o-mini-realtime-preview": {
+            "api": "o"
+        },
+        "gpt-4o-mini-realtime-preview-2024-12-17": {
+            "api": "o"
+        },
+        "gpt-4o-mini-audio-preview": {
+            "api": "o"
+        },
+        "gpt-4o-mini-audio-preview-2024-12-17": {
+            "api": "o"
+        },
+        "gpt-4o-mini": {
+            "api": "o"
+        },
+        "gpt-4o-mini-2024-07-18": {
+            "api": "o"
+        },
+        "chatgpt-4o-latest": {
+            "api": "o"
+        },
+        "gpt-4o-2024-06-26": {
+            "api": "o"
+        },
+        "gpt-4o-mini-tts": {
+            "api": "o"
+        },
+        "o1": {
+            "api": "o"
+        },
+        "o1-2024-12-17": {
+            "api": "o"
+        },
+        "o1-pro": {
+            "api": "o"
+        },
+        "o1-pro-2025-03-19": {
+            "api": "o"
+        },
+        "o3-mini": {
+            "api": "o"
+        },
+        "o3-mini-2025-01-31": {
+            "api": "o"
+        },
+        "o4-mini": {
+            "api": "o-simple"
+        },
+        "o4-mini-2025-04-16": {
+            "api": "o-simple"
+        },
+        "o4-mini-deep-research": {
+            "api": "o-simple"
+        },
+        "o4-mini-deep-research-2025-06-26": {
+            "api": "o-simple"
+        },
+        "o1-mini": {
+            "api": "o-simple"
+        },
+        "o1-mini-2024-09-12": {
+            "api": "o-simple"
+        },
+        "codex-mini-latest": {
+            "api": "o-simple"
+        },
+        "gemini-1.5-pro": {
+            "api": "gemini"
+        },
+        "gemini-1.5-pro-002": {
+            "api": "gemini"
+        },
+        "gemini-1.5-pro-latest": {
+            "api": "gemini"
+        },
+        "gemini-2.5-pro": {
+            "api": "gemini"
+        },
+        "gemini-2.5-pro-preview-03-25": {
+            "api": "gemini"
+        },
+        "gemini-2.5-pro-preview-05-06": {
+            "api": "gemini"
+        },
+        "gemini-2.5-pro-preview-06-05": {
+            "api": "gemini"
+        },
+        "gemini-2.5-pro-preview-tts": {
+            "api": "gemini"
+        },
+        "gemini-2.0-pro-exp": {
+            "api": "gemini"
+        },
+        "gemini-2.0-pro-exp-02-05": {
+            "api": "gemini"
+        },
+        "gemini-exp-1206": {
+            "api": "gemini"
+        },
+        "gemini-2.0-flash-thinking-exp": {
+            "api": "gemini"
+        },
+        "gemini-2.0-flash-thinking-exp-01-21": {
+            "api": "gemini"
+        },
+        "gemini-2.0-flash-thinking-exp-1219": {
+            "api": "gemini"
+        },
+        "gemini-1.5-flash": {
+            "api": "gemini-flash"
+        },
+        "gemini-1.5-flash-002": {
+            "api": "gemini-flash"
+        },
+        "gemini-1.5-flash-latest": {
+            "api": "gemini-flash"
+        },
+        "gemini-1.5-flash-8b": {
+            "api": "gemini-flash"
+        },
+        "gemini-1.5-flash-8b-001": {
+            "api": "gemini-flash"
+        },
+        "gemini-1.5-flash-8b-latest": {
+            "api": "gemini-flash"
+        },
+        "gemini-2.5-flash": {
+            "api": "gemini-flash"
+        },
+        "gemini-2.5-flash-preview-05-20": {
+            "api": "gemini-flash"
+        },
+        "gemini-2.5-flash-lite": {
+            "api": "gemini-flash"
+        },
+        "gemini-2.5-flash-lite-preview-06-17": {
+            "api": "gemini-flash"
+        },
+        "gemini-2.0-flash": {
+            "api": "gemini-flash"
+        },
+        "gemini-2.0-flash-exp": {
+            "api": "gemini-flash"
+        },
+        "gemini-2.0-flash-001": {
+            "api": "gemini-flash"
+        },
+        "gemini-2.0-flash-lite": {
+            "api": "gemini-flash"
+        },
+        "gemini-2.0-flash-lite-001": {
+            "api": "gemini-flash"
+        },
+        "gemini-2.0-flash-lite-preview": {
+            "api": "gemini-flash"
+        },
+        "gemini-2.0-flash-lite-preview-02-05": {
+            "api": "gemini-flash"
+        },
+        "gemini-2.5-flash-preview-native-audio-dialog": {
+            "api": "gemini-flash"
+        },
+        "gemini-2.5-flash-exp-native-audio-thinking-dialog": {
+            "api": "gemini-flash"
+        },
+        "gemini-2.0-flash-live-001": {
+            "api": "gemini-flash"
+        },
+        "gemini-live-2.5-flash-preview": {
+            "api": "gemini-flash"
+        },
+        "gemini-2.5-flash-live-preview": {
+            "api": "gemini-flash"
+        },
+        "gemini-2.5-flash-preview-tts": {
+            "api": "gemini-flash"
+        },
+        "learnlm-2.0-flash-experimental": {
+            "api": "gemini-flash"
+        },
+        "claude-opus-4-20250514": {
+            "api": "claude"
+        },
+        "claude-sonnet-4-20250514": {
+            "api": "claude"
+        },
+        "claude-3-7-sonnet-20250219": {
+            "api": "claude"
+        },
+        "claude-3-5-sonnet-20241022": {
+            "api": "claude"
+        },
+        "claude-3-5-haiku-20241022": {
+            "api": "claude"
+        },
+        "claude-3-5-sonnet-20240620": {
+            "api": "claude"
+        },
+        "claude-3-haiku-20240307": {
+            "api": "claude"
+        },
+        "deepseek-v4-flash": {
+            "api": "gpt4"
+        },
+        "deepseek-v4-pro": {
+            "api": "gpt4"
+        },
+        "claude-haiku-4-5-20251001": {
+            "api": "claude"
+        },
+        "claude-sonnet-4-6": {
+            "api": "claude"
+        }
     },
     "important": [
-    "gpt-3.5-turbo",
-    "gpt-4",
-    "gpt-4o",
-    "gpt-4o-mini",
-    "o1",
-    "o3-mini",
-    "o4-mini",
-    "gpt-5",
-    "gpt-5-mini",
-    "gemini-2.5-pro",
-    "gemini-2.5-flash",
-    "gemini-2.5-pro-preview-06-05",
-    "gemini-1.5-pro",
-    "claude-opus-4-20250514",       
-    "claude-sonnet-4-20250514",     
-    "claude-3-7-sonnet-20250219",   
-    "claude-3-5-haiku-20241022"
-  ]
+        "gpt-3.5-turbo",
+        "gpt-4",
+        "gpt-4o",
+        "gpt-4o-mini",
+        "o1",
+        "o3-mini",
+        "o4-mini",
+        "gpt-5",
+        "gpt-5-mini",
+        "gemini-2.5-pro",
+        "gemini-2.5-flash",
+        "gemini-2.5-pro-preview-06-05",
+        "gemini-1.5-pro",
+        "claude-opus-4-20250514",
+        "claude-sonnet-4-20250514",
+        "claude-3-7-sonnet-20250219",
+        "claude-3-5-haiku-20241022",
+        "deepseek-v4-flash",
+        "deepseek-v4-pro",
+        "claude-haiku-4-5-20251001",
+        "claude-sonnet-4-6"
+    ]
 }

--- a/convert.py
+++ b/convert.py
@@ -272,9 +272,18 @@ class OpenAI_API(LLM_API):
         self.client = OpenAI() if self.org_id is None else OpenAI(organization=self.org_id)
         self.models = self.client.models.list()
       except Exception as e:
-        print(f"Warning: Failed to initialize OpenAI API: {e}")
-        self.client = None
-        self.models = None
+        # Some OpenAI-compatible endpoints (e.g. GitHub Models) do not support the
+        # /models listing. Allow the model list to be provided via OPENAI_MODEL_LIST
+        # (comma-separated ids) so such endpoints can still be used together with
+        # OPENAI_BASE_URL.
+        if self.client is not None and os.getenv("OPENAI_MODEL_LIST"):
+          from types import SimpleNamespace
+          ids = [i.strip() for i in os.getenv("OPENAI_MODEL_LIST").split(",") if i.strip()]
+          self.models = SimpleNamespace(data=[SimpleNamespace(id=i) for i in ids])
+        else:
+          print(f"Warning: Failed to initialize OpenAI API: {e}")
+          self.client = None
+          self.models = None
     else:
       self.client = None
       self.models = None


### PR DESCRIPTION
The OpenAI client already honors OPENAI_BASE_URL, which lets convert.py run against any OpenAI-compatible provider (DeepSeek, Groq, GitHub Models). This is how the counter comparison ran DeepSeek, Llama and the GitHub-hosted models.

Two small things were needed:

1. Some endpoints (GitHub Models) do not implement the /models listing, which made initialization fail. When the listing fails and OPENAI_MODEL_LIST is set (comma-separated ids), it is used as the model list instead.

2. config/models.json had stale model names: DeepSeek's API now lists deepseek-v4-flash and deepseek-v4-pro (deepseek-chat is being retired), and Anthropic's current models are claude-haiku-4-5-20251001 and claude-sonnet-4-6. The previous claude entries are no longer returned by the API, so automation offered no Claude model at all.

Usage example: OPENAI_BASE_URL=https://api.deepseek.com OPENAI_API_KEY=... python3 convert.py